### PR TITLE
Update some github api calls response header from http 1.1 to 1.0

### DIFF
--- a/includes/pipeline_page/_index.php
+++ b/includes/pipeline_page/_index.php
@@ -136,14 +136,14 @@ if ((!file_exists($gh_pipeline_schema_fn) && !file_exists($gh_pipeline_no_schema
     $api_opts = stream_context_create(['http' => ['method' => 'GET', 'header' => ['User-Agent: PHP']]]);
     $gh_launch_schema_url = "https://api.github.com/repos/sanger-tol/{$pipeline->name}/contents/nextflow_schema.json?ref={$release}";
     $gh_launch_schema_json = file_get_contents($gh_launch_schema_url, false, $api_opts);
-    if (strpos($http_response_header[0], 'HTTP/1.1 200') === false) {
+    if (strpos($http_response_header[0], 'HTTP/1.0 200') === false) {
         echo '<script>console.log("Sent request to ' .
             $gh_launch_schema_url .
             '"," got http response header:",' .
             json_encode($http_response_header, JSON_HEX_TAG) .
             ')</script>';
         # Remember for next time
-        if (strpos($http_response_header[0], 'HTTP/1.1 404') !== false) {
+        if (strpos($http_response_header[0], 'HTTP/1.0 404') !== false) {
             file_put_contents($gh_pipeline_no_schema_fn, '');
         }
     } else {

--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -105,6 +105,7 @@ function launch_pipeline_web($pipeline, $release) {
         $gh_launch_schema_url = basename($release);
         $gh_launch_schema_url = "https://api.github.com/repos/sanger-tol/{$pipeline}/contents/nextflow_schema.json?ref={$gh_launch_schema_url}";
         $gh_launch_schema_json = file_get_contents($gh_launch_schema_url, false, $api_opts);
+        
         if (strpos($http_response_header[0], 'HTTP/1.1 200') === false) {
             # Remember for next time
             file_put_contents($gh_pipeline_no_schema_fn, '');

--- a/public_html/pipeline_health.php
+++ b/public_html/pipeline_health.php
@@ -213,12 +213,12 @@ class RepoHealth {
                 $gh_branch_url =
                     'https://api.github.com/repos/sanger-tol/' . basename($this->name) . '/branches/' . $branch . '/protection';
                 $gh_branch = json_decode(@file_get_contents($gh_branch_url, false, GH_API_OPTS));
-                if (strpos($http_response_header[0], 'HTTP/1.1 200') !== false && is_object($gh_branch)) {
+                if (strpos($http_response_header[0], 'HTTP/1.0 200') !== false && is_object($gh_branch)) {
                     $this->{'gh_branch_' . $branch} = $gh_branch;
                     $this->_save_cache_data($gh_branch_cache, $this->{'gh_branch_' . $branch});
                 } else {
                     // Write an empty cache file
-                    if (strpos($http_response_header[0], 'HTTP/1.1 404') === false) {
+                    if (strpos($http_response_header[0], 'HTTP/1.0 404') === false) {
                         // A 404 is fine, that just means that there is no branch protection. Warn if anything else.
                         $gh_branch = htmlspecialchars($gh_branch, ENT_QUOTES, 'UTF-8');
                         echo '<div class="alert alert-danger">Could not fetch branch protection data for <code>' .
@@ -555,9 +555,9 @@ class RepoHealth {
             ],
         ]);
         $result = json_decode(file_get_contents($url, false, $context));
-        if (strpos($http_response_header[0], 'HTTP/1.1 204') !== false) {
+        if (strpos($http_response_header[0], 'HTTP/1.0 204') !== false) {
             return true;
-        } elseif (strpos($http_response_header[0], 'HTTP/1.1 200') !== false) {
+        } elseif (strpos($http_response_header[0], 'HTTP/1.0 200') !== false) {
             return $result;
         } else {
             echo '<div class="alert alert-danger m-3">

--- a/update_issue_stats.php
+++ b/update_issue_stats.php
@@ -142,7 +142,7 @@ foreach ($repos as $repo) {
         }
         $num_api_calls += 1;
         $gh_issues = json_decode(file_get_contents($gh_issues_url, false, $gh_api_opts), true);
-        if (strpos($http_response_header[0], 'HTTP/1.1 200') === false) {
+        if (strpos($http_response_header[0], 'HTTP/1.0 200') === false) {
             var_dump($http_response_header);
             echo "\nCould not fetch nf-core/$repo issues! $gh_issues_url\n";
             continue;
@@ -269,7 +269,7 @@ foreach ($repos as $repo) {
                     $num_api_calls += 1;
                     $gh_new_comments = json_decode(file_get_contents($gh_comments_url, false, $gh_api_opts), true);
                     $gh_comments = array_merge($gh_comments, $gh_new_comments);
-                    if (strpos($http_response_header[0], 'HTTP/1.1 200') === false) {
+                    if (strpos($http_response_header[0], 'HTTP/1.0 200') === false) {
                         var_dump($http_response_header);
                         echo "\nCould not fetch nf-core/$repo issue #$id! $gh_comments_url\n";
                         continue;

--- a/update_module_details.php
+++ b/update_module_details.php
@@ -51,7 +51,7 @@ function github_query($gh_query_url) {
             $gh_query_url = $next_page;
         }
         $tmp_results = json_decode(file_get_contents($gh_query_url, false, $gh_api_opts), true);
-        if (strpos($http_response_header[0], 'HTTP/1.1 200') === false) {
+        if (strpos($http_response_header[0], 'HTTP/1.0 200') === false) {
             var_dump($http_response_header);
             echo "\nCould not fetch $gh_query_url";
             continue;

--- a/update_pipeline_details.php
+++ b/update_pipeline_details.php
@@ -55,7 +55,7 @@ function get_gh_api($gh_api_url) {
             $gh_api_url = $next_page;
         }
         $tmp_results = json_decode(file_get_contents($gh_api_url, false, $gh_api_opts));
-        if (strpos($http_response_header[0], 'HTTP/1.1 200') === false) {
+        if (strpos($http_response_header[0], 'HTTP/1.0 200') === false) {
             die("\n-------- START ERROR " . date('Y-m-d h:i:s') . " --------\nCould not fetch $gh_api_url \n");
             var_dump($http_response_header);
             echo "\n$tmp_results\n";

--- a/update_stats.php
+++ b/update_stats.php
@@ -58,13 +58,13 @@ function github_query($gh_query_url) {
         // If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response;
         // a background job is also fired to start compiling these statistics.
         // Give the job a few moments to complete, and then submit the request again
-        if (strpos($http_response_header[0], 'HTTP/1.1 202') !== false) {
+        if (strpos($http_response_header[0], 'HTTP/1.0 202') !== false) {
             echo "Waiting for GitHub API to return results for $gh_query_url \n";
             sleep(10);
             $first_page = true;
             continue;
         }
-        if (strpos($http_response_header[0], 'HTTP/1.1 200') === false) {
+        if (strpos($http_response_header[0], 'HTTP/1.0 200') === false) {
             var_dump($http_response_header);
             echo "\nCould not fetch $gh_query_url";
             continue;
@@ -357,7 +357,7 @@ while ($first_page || $next_page) {
         $gh_members_url = $next_page;
     }
     $gh_members = json_decode(file_get_contents($gh_members_url, false, $gh_api_opts));
-    if (strpos($http_response_header[0], 'HTTP/1.1 200') === false) {
+    if (strpos($http_response_header[0], 'HTTP/1.0 200') === false) {
         var_dump($http_response_header);
         echo "Could not fetch nf-core members! $gh_members_url";
         continue;
@@ -378,10 +378,11 @@ while ($first_page || $next_page) {
 echo "Get the list of repos from Github\n";
 $gh_repos_url = 'https://api.github.com/orgs/sanger-tol/repos?per_page=100';
 $gh_repos = json_decode(file_get_contents($gh_repos_url, false, $gh_api_opts));
-if (strpos($http_response_header[0], 'HTTP/1.1 200') === false) {
+if (strpos($http_response_header[0], 'HTTP/1.0 200') === false) {
     var_dump($http_response_header);
     die("Could not fetch nf-core repositories! $gh_repos_url");
 }
+
 foreach ($gh_repos as $repo) {
     if (in_array($repo->name, $ignored_repos)) {
         $repo_type = 'core_repos';
@@ -409,7 +410,7 @@ foreach ($gh_repos as $repo) {
     // Annoyingly, two values are only available if we query for just this repo
     $gh_repo_url = 'https://api.github.com/repos/sanger-tol/' . basename($repo->name);
     $gh_repo = json_decode(file_get_contents($gh_repo_url, false, $gh_api_opts));
-    if (strpos($http_response_header[0], 'HTTP/1.1 200') === false) {
+    if (strpos($http_response_header[0], 'HTTP/1.0 200') === false) {
         var_dump($http_response_header);
         echo "Could not fetch nf-core repo! $gh_repo_url";
         continue;
@@ -427,9 +428,9 @@ foreach (['pipelines'] as $repo_type) {
         // Views
         $gh_views_url = 'https://api.github.com/repos/sanger-tol/' . $repo_name . '/traffic/views';
         $gh_views = json_decode(file_get_contents($gh_views_url, false, $gh_api_opts));
-        if (strpos($http_response_header[0], 'HTTP/1.1 200') === false) {
+        if (strpos($http_response_header[0], 'HTTP/1.0 200') === false) {
             // Pipelines are removed from the cache earlier as we know their names
-            if ($repo_type == 'core_repos' && strpos($http_response_header[0], 'HTTP/1.1 404') !== false) {
+            if ($repo_type == 'core_repos' && strpos($http_response_header[0], 'HTTP/1.0 404') !== false) {
                 echo 'Removing ' . $repo_name . " from the cached results as it appears to have been deleted.\n";
                 unset($results['core_repos'][$repo_name]);
             } else {
@@ -446,7 +447,7 @@ foreach (['pipelines'] as $repo_type) {
         // Clones
         $gh_clones_url = 'https://api.github.com/repos/sanger-tol/' . $repo_name . '/traffic/clones';
         $gh_clones = json_decode(file_get_contents($gh_clones_url, false, $gh_api_opts));
-        if (strpos($http_response_header[0], 'HTTP/1.1 200') === false) {
+        if (strpos($http_response_header[0], 'HTTP/1.0 200') === false) {
             var_dump($http_response_header);
             echo "Could not fetch nf-core repo clones! $gh_clones_url";
             continue;
@@ -463,12 +464,12 @@ foreach (['pipelines'] as $repo_type) {
         // If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response;
         // a background job is also fired to start compiling these statistics.
         // Give the job a few moments to complete, and then submit the request again
-        if (strpos($http_response_header[0], 'HTTP/1.1 202') !== false) {
+        if (strpos($http_response_header[0], 'HTTP/1.0 202') !== false) {
             $contribs_try_again[$repo_name] = [
                 'repo_type' => $repo_type,
                 'gh_contributors_url' => $gh_contributors_url,
             ];
-        } elseif (strpos($http_response_header[0], 'HTTP/1.1 200') === false) {
+        } elseif (strpos($http_response_header[0], 'HTTP/1.0 200') === false) {
             var_dump($http_response_header);
             echo "Could not fetch nf-core repo contributors! $gh_contributors_url";
             continue;
@@ -508,10 +509,10 @@ if (count($contribs_try_again) > 0) {
         $gh_contributors_raw = file_get_contents($gh_contributors_url, false, $gh_api_opts);
         file_put_contents($contribs_fn_root . $repo_name . '.json', $gh_contributors_raw);
         $gh_contributors = json_decode($gh_contributors_raw);
-        if (strpos($http_response_header[0], 'HTTP/1.1 202') !== false) {
+        if (strpos($http_response_header[0], 'HTTP/1.0 202') !== false) {
             echo "Tried getting contributors after delay for $repo_name, but took too long.\n";
             continue;
-        } elseif (strpos($http_response_header[0], 'HTTP/1.1 200') === false) {
+        } elseif (strpos($http_response_header[0], 'HTTP/1.0 200') === false) {
             var_dump($http_response_header);
             echo "Could not fetch nf-core repo contributors! $gh_contributors_url";
             continue;


### PR DESCRIPTION
1. Most GitHub API call from PHP using request with `Authorization: Basic `, which response header will chane to HTTP/1.0
2. When request without authorization set, like in launch page, the response header not changed, still HTTP/1.1. But sometimes may get HTTP/1.1 403.
3. Tried Github API query using other methods, normally response with HTTP/2.